### PR TITLE
Support for Ruby 2.x

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -3,8 +3,11 @@ require 'mkmf'
 if ! defined? PLATFORM
   PLATFORM = RUBY_PLATFORM
 end
+# 2.0+
 #adding this for backward compatible
-(have_header('ruby/thread.h') && have_func('rb_thread_call_without_gvl', 'ruby/thread.h')) || have_func('rb_thread_blocking_region')
+have_header('ruby/thread.h') && have_func('rb_thread_call_without_gvl', 'ruby/thread.h')
+# 1.9-only
+have_func('rb_thread_blocking_region')
 
 def have_library_ex(lib, func="main", headers=nil)
   checking_for "#{func}() in -l#{lib}" do

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -3,6 +3,8 @@ require 'mkmf'
 if ! defined? PLATFORM
   PLATFORM = RUBY_PLATFORM
 end
+#adding this for backward compatible
+(have_header('ruby/thread.h') && have_func('rb_thread_call_without_gvl', 'ruby/thread.h')) || have_func('rb_thread_blocking_region')
 
 def have_library_ex(lib, func="main", headers=nil)
   checking_for "#{func}() in -l#{lib}" do

--- a/ext/odbc.c
+++ b/ext/odbc.c
@@ -152,40 +152,7 @@ static SQLRETURN tracesql(SQLHENV henv, SQLHDBC hdbc, SQLHSTMT hstmt,
 /* emulate rb_thread_call_without_gvl with rb_thread_blocking_region */
 //#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
   //rb_thread_blocking_region((rb_blocking_function_t *)func, data1, ubf, data2)
-#ifndef HAVE_RB_THREAD_CALL_WITHOUT_GVL
-#ifdef HAVE_RB_THREAD_BLOCKING_REGION
 
-/* emulate rb_thread_call_without_gvl with rb_thread_blocking_region */
-#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
-  rb_thread_blocking_region((rb_blocking_function_t *)func, data1, ubf, data2)
-
-#else /* ! HAVE_RB_THREAD_BLOCKING_REGION */
-/*
- * partial emulation of the 2.0 rb_thread_call_without_gvl under 1.8,
- * this is enough for dealing with blocking I/O functions in the
- * presence of threads.
- */
-
-#include <rubysig.h>
-#define RUBY_UBF_IO ((rb_unblock_function_t *)-1)
-typedef void rb_unblock_function_t(void *);
-static void *
-rb_thread_call_without_gvl(
-   void *(*func)(void *), void *data1,
-  RB_MYSQL_UNUSED rb_unblock_function_t *ubf,
-  RB_MYSQL_UNUSED void *data2)
-{
-  void *rv;
-
-  TRAP_BEG;
-  rv = func(data1);
-  TRAP_END;
-
-  return rv;
-}
-
-#endif /* ! HAVE_RB_THREAD_BLOCKING_REGION */
-#endif /* ! HAVE_RB_THREAD_CALL_WITHOUT_GVL */
   ///////////////////////////////////
   
 typedef struct _SQLExecDirect_Args {

--- a/ext/odbc.c
+++ b/ext/odbc.c
@@ -149,9 +149,20 @@ static SQLRETURN tracesql(SQLHENV henv, SQLHDBC hdbc, SQLHSTMT hstmt,
 
 ////////////////////////////////////////////////////////////////
 
-/* emulate rb_thread_call_without_gvl with rb_thread_blocking_region */
+#ifdef HAVE_RB_THREAD_BLOCKING_REGION
 #define rb_thread_call_without_gvl(func, data1, ubf, data2) \
   rb_thread_blocking_region((rb_blocking_function_t *)func, data1, ubf, data2)
+  #else
+#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
+	  rb_thread_call_without_gvl((rb_blocking_function_t *)func, data1, ubf, data2)
+#endif
+
+/* emulate rb_thread_call_without_gvl with rb_thread_blocking_region */
+//#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
+//  rb_thread_blocking_region((rb_blocking_function_t *)func, data1, ubf, data2)
+
+//#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
+//	  rb_thread_call_without_gvl((rb_blocking_function_t *)func, data1, ubf, data2)
 
 //#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
   //rb_thread_call_without_gvl((rb_blocking_function_t *)func, data1, ubf, data2)

--- a/ext/odbc.c
+++ b/ext/odbc.c
@@ -150,11 +150,11 @@ static SQLRETURN tracesql(SQLHENV henv, SQLHDBC hdbc, SQLHSTMT hstmt,
 ////////////////////////////////////////////////////////////////
 
 /* emulate rb_thread_call_without_gvl with rb_thread_blocking_region */
-//#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
-  //rb_thread_blocking_region((rb_blocking_function_t *)func, data1, ubf, data2)
-
 #define rb_thread_call_without_gvl(func, data1, ubf, data2) \
-  rb_thread_call_without_gvl((rb_blocking_function_t *)func, data1, ubf, data2)
+  rb_thread_blocking_region((rb_blocking_function_t *)func, data1, ubf, data2)
+
+//#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
+  //rb_thread_call_without_gvl((rb_blocking_function_t *)func, data1, ubf, data2)
   ///////////////////////////////////
   
 typedef struct _SQLExecDirect_Args {

--- a/ext/odbc.c
+++ b/ext/odbc.c
@@ -152,7 +152,42 @@ static SQLRETURN tracesql(SQLHENV henv, SQLHDBC hdbc, SQLHSTMT hstmt,
 /* emulate rb_thread_call_without_gvl with rb_thread_blocking_region */
 //#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
   //rb_thread_blocking_region((rb_blocking_function_t *)func, data1, ubf, data2)
+#ifndef HAVE_RB_THREAD_CALL_WITHOUT_GVL
+#ifdef HAVE_RB_THREAD_BLOCKING_REGION
 
+/* emulate rb_thread_call_without_gvl with rb_thread_blocking_region */
+#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
+  rb_thread_blocking_region((rb_blocking_function_t *)func, data1, ubf, data2)
+
+#else /* ! HAVE_RB_THREAD_BLOCKING_REGION */
+/*
+ * partial emulation of the 2.0 rb_thread_call_without_gvl under 1.8,
+ * this is enough for dealing with blocking I/O functions in the
+ * presence of threads.
+ */
+
+#include <rubysig.h>
+#define RUBY_UBF_IO ((rb_unblock_function_t *)-1)
+typedef void rb_unblock_function_t(void *);
+static void *
+rb_thread_call_without_gvl(
+   void *(*func)(void *), void *data1,
+  RB_MYSQL_UNUSED rb_unblock_function_t *ubf,
+  RB_MYSQL_UNUSED void *data2)
+{
+  void *rv;
+
+  TRAP_BEG;
+  rv = func(data1);
+  TRAP_END;
+
+  return rv;
+}
+
+#endif /* ! HAVE_RB_THREAD_BLOCKING_REGION */
+#endif /* ! HAVE_RB_THREAD_CALL_WITHOUT_GVL */
+  ///////////////////////////////////
+  
 typedef struct _SQLExecDirect_Args {
   SQLHSTMT    StatementHandle;
 #ifdef _UNICODE

--- a/ext/odbc.c
+++ b/ext/odbc.c
@@ -153,6 +153,8 @@ static SQLRETURN tracesql(SQLHENV henv, SQLHDBC hdbc, SQLHSTMT hstmt,
 //#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
   //rb_thread_blocking_region((rb_blocking_function_t *)func, data1, ubf, data2)
 
+#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
+  rb_thread_call_without_gvl((rb_blocking_function_t *)func, data1, ubf, data2)
   ///////////////////////////////////
   
 typedef struct _SQLExecDirect_Args {

--- a/ext/odbc.c
+++ b/ext/odbc.c
@@ -150,7 +150,7 @@ static SQLRETURN tracesql(SQLHENV henv, SQLHDBC hdbc, SQLHSTMT hstmt,
 ////////////////////////////////////////////////////////////////
 
 /* emulate rb_thread_call_without_gvl with rb_thread_blocking_region */
-//#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
+#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
   //rb_thread_blocking_region((rb_blocking_function_t *)func, data1, ubf, data2)
 
 typedef struct _SQLExecDirect_Args {

--- a/ext/odbc.c
+++ b/ext/odbc.c
@@ -151,8 +151,8 @@ static SQLRETURN tracesql(SQLHENV henv, SQLHDBC hdbc, SQLHSTMT hstmt,
 
 /* emulate rb_thread_call_without_gvl with rb_thread_blocking_region */
 #define rb_thread_call_without_gvl(func, data1, ubf, data2) \
-  rb_thread_blocking_region((rb_blocking_function_t *)func, data1, ubf, data2)
-
+  #rb_thread_blocking_region((rb_blocking_function_t *)func, data1, ubf, data2)  
+  rb_thread_call_without_gvl ((rb_blocking_function_t *)func, data1, ubf, data2)
 typedef struct _SQLExecDirect_Args {
   SQLHSTMT    StatementHandle;
 #ifdef _UNICODE

--- a/ext/odbc.c
+++ b/ext/odbc.c
@@ -150,8 +150,8 @@ static SQLRETURN tracesql(SQLHENV henv, SQLHDBC hdbc, SQLHSTMT hstmt,
 ////////////////////////////////////////////////////////////////
 
 /* emulate rb_thread_call_without_gvl with rb_thread_blocking_region */
-#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
-  #rb_thread_blocking_region((rb_blocking_function_t *)func, data1, ubf, data2)
+//#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
+  //rb_thread_blocking_region((rb_blocking_function_t *)func, data1, ubf, data2)
 
 typedef struct _SQLExecDirect_Args {
   SQLHSTMT    StatementHandle;

--- a/ext/odbc.c
+++ b/ext/odbc.c
@@ -151,24 +151,9 @@ static SQLRETURN tracesql(SQLHENV henv, SQLHDBC hdbc, SQLHSTMT hstmt,
 
 #ifdef HAVE_RB_THREAD_BLOCKING_REGION
 #define rb_thread_call_without_gvl(func, data1, ubf, data2) \
-  printf("this is ruby < 2 as rb_thread_blocking_region is called");
   rb_thread_blocking_region((rb_blocking_function_t *)func, data1, ubf, data2)
-//  #else
-//#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
-//	  rb_thread_call_without_gvl((rb_blocking_function_t *)func, data1, ubf, data2)
 #endif
 
-/* emulate rb_thread_call_without_gvl with rb_thread_blocking_region */
-//#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
-//  rb_thread_blocking_region((rb_blocking_function_t *)func, data1, ubf, data2)
-
-//#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
-//	  rb_thread_call_without_gvl((rb_blocking_function_t *)func, data1, ubf, data2)
-
-//#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
-  //rb_thread_call_without_gvl((rb_blocking_function_t *)func, data1, ubf, data2)
-  ///////////////////////////////////
-  
 typedef struct _SQLExecDirect_Args {
   SQLHSTMT    StatementHandle;
 #ifdef _UNICODE

--- a/ext/odbc.c
+++ b/ext/odbc.c
@@ -149,51 +149,6 @@ static SQLRETURN tracesql(SQLHENV henv, SQLHDBC hdbc, SQLHSTMT hstmt,
 
 ////////////////////////////////////////////////////////////////
 
-/* emulate rb_thread_call_without_gvl with rb_thread_blocking_region */
-#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
-  #rb_thread_blocking_region((rb_blocking_function_t *)func, data1, ubf, data2)  
-  rb_thread_call_without_gvl ((rb_blocking_function_t *)func, data1, ubf, data2)
-typedef struct _SQLExecDirect_Args {
-  SQLHSTMT    StatementHandle;
-#ifdef _UNICODE
-  SQLWCHAR    *StatementText;
-#else
-  SQLCHAR    *StatementText;
-#endif
-  SQLINTEGER  TextLength;
-} SQLExecDirect_Args;
-
-typedef struct _SQLExecute_Args {
-  SQLHSTMT    StatementHandle;
-} SQLExecute_Args;
-
-VALUE
-SQLExecute_wrapper(void *data)
-{
-	SQLExecute_Args *args = (SQLExecute_Args *)data;
-  return SQLExecute(args->StatementHandle);
-}
-
-void
-SQLExecute_unblock(void *data)
-{
-	SQLExecute_Args *args = (SQLExecute_Args *)data;
-	SQLCancel(args->StatementHandle);
-}
-
-VALUE
-SQLExecDirect_wrapper(void *data)
-{
-	SQLExecDirect_Args *args = (SQLExecDirect_Args *)data;
-  return SQLExecDirect(args->StatementHandle, args->StatementText, args->TextLength);
-}
-
-void
-SQLExecDirect_unblock(void *data)
-{
-	SQLExecDirect_Args *args = (SQLExecDirect_Args *)data;
-	SQLCancel(args->StatementHandle);
-}
 
 ////////////////////////////////////////////////////////////////
 

--- a/ext/odbc.c
+++ b/ext/odbc.c
@@ -151,10 +151,11 @@ static SQLRETURN tracesql(SQLHENV henv, SQLHDBC hdbc, SQLHSTMT hstmt,
 
 #ifdef HAVE_RB_THREAD_BLOCKING_REGION
 #define rb_thread_call_without_gvl(func, data1, ubf, data2) \
+  printf("this is ruby < 2 as rb_thread_blocking_region is called");
   rb_thread_blocking_region((rb_blocking_function_t *)func, data1, ubf, data2)
-  #else
-#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
-	  rb_thread_call_without_gvl((rb_blocking_function_t *)func, data1, ubf, data2)
+//  #else
+//#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
+//	  rb_thread_call_without_gvl((rb_blocking_function_t *)func, data1, ubf, data2)
 #endif
 
 /* emulate rb_thread_call_without_gvl with rb_thread_blocking_region */

--- a/ext/odbc.c
+++ b/ext/odbc.c
@@ -150,7 +150,7 @@ static SQLRETURN tracesql(SQLHENV henv, SQLHDBC hdbc, SQLHSTMT hstmt,
 ////////////////////////////////////////////////////////////////
 
 /* emulate rb_thread_call_without_gvl with rb_thread_blocking_region */
-#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
+//#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
   //rb_thread_blocking_region((rb_blocking_function_t *)func, data1, ubf, data2)
 
 typedef struct _SQLExecDirect_Args {


### PR DESCRIPTION
In Ruby 2.x, the function "rb_thread_call_without_gvl" is used to release the GIL.
To support Ruby 1.9.3, the previous code defined a placeholder "rb_thread_call_without_gvl" function that called the old-style function "rb_thread_blocking_region"

This change creates a predef hack to avoid the re-definition of this function when compiled with Ruby 2.x.

See: https://github.com/ruby/ruby/blob/v2_0_0_247/thread.c#L1231-L1315
