### PR TITLE
[AVM-8821] Fixing invalid operands to binary / (have 'int' and 'char*') error when upgrading to ruby 2.4.5

### DIFF
--- a/ext/odbc.c
+++ b/ext/odbc.c
@@ -4381,8 +4381,11 @@ do_option(int argc, VALUE *argv, VALUE self, int isstmt, int op)
     SQLINTEGER v;
     char *msg;
     int level = isstmt ? OPT_LEVEL_STMT : OPT_LEVEL_DBC;
-
-    rb_scan_args(argc, argv, (op == -1) ? "11" : "01", &val, &val2);
+    char *opvalue = "01";
+    if(op == -1) {
+        opvalue == "11";
+    }
+    rb_scan_args(argc, argv, opvalue, &val, &val2);
     if (isstmt) {
 	Data_Get_Struct(self, STMT, q);
 	if (q->dbc == Qnil) {


### PR DESCRIPTION
On upgrading AVM to 2.4.5, an error occurs while bundling ruby-odbc.
C:/Ruby24-x64/include/ruby-2.4.0/ruby/ruby.h:2170:12: error: invalid operands to binary / (have 'int' and 'char *')
((vari)/(!fmt[ofs] || rb_scan_args_bad_format(fmt)))

Manual Tests:
Have tested by building the gem in mac/windows machine and then installing the gem locally.
Have tested by bundling by specifying the repo in AVM gemfile.
Have tested by running rspec and running AVM