### PR TITLE
[AVM-8825] Fixing Reference errors by removing empty params from have_func method

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -95,9 +95,9 @@ if PLATFORM =~ /mswin32/ then
   have_func("SQLInstallerError", "odbcinst.h")
 # mingw untested !!!
 elsif PLATFORM =~ /(mingw|cygwin)/ then
-  have_library("odbc32", "")
-  have_library("odbccp32", "")
-  have_library("user32", "")
+  have_library("odbc32")
+  have_library("odbccp32")
+  have_library("user32")
 elsif (testdlopen && PLATFORM !~ /(macos|darwin)/ && CONFIG["CC"] =~ /gcc/ && have_func("dlopen", "dlfcn.h") && have_library("dl", "dlopen")) then
   $LDFLAGS+=" -Wl,-init -Wl,ruby_odbc_init -Wl,-fini -Wl,ruby_odbc_fini"
   $CPPFLAGS+=" -DHAVE_SQLCONFIGDATASOURCE"

--- a/ext/utf8/extconf.rb
+++ b/ext/utf8/extconf.rb
@@ -113,9 +113,9 @@ if PLATFORM =~ /mswin32/ then
   have_func("SQLInstallerError", "odbcinst.h")
   have_func("SQLInstallerErrorW", "odbcinst.h")
 elsif PLATFORM =~ /(mingw|cygwin)/ then
-  have_library("odbc32", "")
-  have_library("odbccp32", "")
-  have_library("user32", "")
+  have_library("odbc32")
+  have_library("odbccp32")
+  have_library("user32")
   header = ["windows.h", "odbcinst.h"]
   have_func("SQLConfigDataSourceW", header)
   have_func("SQLWriteFileDSNW", header)


### PR DESCRIPTION
We encounter reference errors while bundling ruby-odbc with ruby 2.4.5.
This is because of passing empty as a second argument to have_func()

Refer patch: https://translate.googleusercontent.com/translate_c?depth=1&hl=en&prev=search&rurl=translate.google.com&sl=ja&sp=nmt4&u=https://gist.github.com/larskanis/503f0a24af6ee871a8666c6e3a037487&xid=25657,15700021,15700186,15700190,15700248,15700253&usg=ALkJrhhWrL3IT_6hR8ZqJON9QCDXRbx_mg

#### Manual Tests:
Have tested by building the gem in mac/windows machine and then installing the gem locally.
Have tested by bundling by specifying the repo in AVM gemfile.
Have tested by running rspec and running AVM
Have tested by running rspec with older version of AVM i.e AVM with ruby 2.3.8