### PR TITLE
Support for Ruby 3.3.x

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 ODBC binding for Ruby
 ---------------------
+Thu Jun 27 2024 version 0.103.cv release <pandeyam@vmware.com>
+	* Argument data type fix to support Ruby 3.3 by replacing NULL with 0 in method rb_funcall
+	* Include ruby/thread.h to implicitly declare rb_thread_call_without_gvl
+	* Cast first argument of rb_thread_call_without_gvl to void * data type
+
 Mon Aug 21 2023 version 0.102.cv release <grajwade@vmware.com>
 	* Syntax changes to support Ruby 3.2 by using native "rb_str_new" instead of "rb_tainted_str_new"
           Remove tained usage (thanks @vhermecz)

--- a/ruby-odbc.gemspec
+++ b/ruby-odbc.gemspec
@@ -1,7 +1,7 @@
 require 'date'
 spec = Gem::Specification.new do |s|
   s.name = "ruby-odbc"
-  s.version = "0.102.cv"
+  s.version = "0.103.cv"
   s.date = Date.today.to_s
   s.author = "Christian Werner"
   s.email = "chw @nospam@ ch-werner.de"


### PR DESCRIPTION
- rb_funcall method when called with 0 as a third argument does not support NULL as the 4th argument. It should be replaced with 0 https://blog.peterzhu.ca/ruby-c-ext-part-3/
- Include header ruby/thread.h for method rb_thread_call_without_gvl to fix implicit declaration of method error
- First argument of rb_thread_call_without_gvl method should be type void *(*func)(void *). In the code the argument type was VALUE(*func)(void *). Implement SQLExecDirect_wrapper_with_gvl to type caste the result of SQLExecDirect_wrapper into void *